### PR TITLE
Force iOS UISlider to work with discrete steps

### DIFF
--- a/cars/car-detail-edit-page/car-detail-edit-page.xml
+++ b/cars/car-detail-edit-page/car-detail-edit-page.xml
@@ -26,7 +26,7 @@
                         </FormattedString>
                     </Label>
                 </GridLayout>
-                <Slider value="{{ car.price }}" />
+                <Slider value="{{ car.price, car.price | roundingValueConverter }}" />
 
                 <Label text="ADD OR REMOVE IMAGE" />
                 <!--
@@ -68,7 +68,7 @@
                         </FormattedString>
                     </Label>
                 </GridLayout>
-                <Slider minValue="{{ carLuggageMinValue }}" maxValue="{{ carLuggageMaxValue }}" value="{{ car.luggage }}" />
+                <Slider minValue="0" maxValue="5" value="{{ car.luggage, car.luggage | roundingValueConverter }}" />
 
             </StackLayout>
         </ScrollView>

--- a/cars/car-detail-edit-page/car-detail-edit-view-model.ts
+++ b/cars/car-detail-edit-page/car-detail-edit-view-model.ts
@@ -5,6 +5,7 @@ import * as platform from "tns-core-modules/platform";
 import firebase = require("nativescript-plugin-firebase");
 
 import { Car } from "../shared/car-model";
+import { RoundingValueConverter } from "./RoundingValueConverter";
 
 const faPlusIcon = "\uf067";
 const faThrashIcon = "\uf014";
@@ -20,9 +21,8 @@ const editableProperties = [
 ];
 
 export class CarDetailEditViewModel extends Observable {
+    private _roundingValueConverter: RoundingValueConverter;
     private _addRemoveText: string;
-    private _carLuggageMinValue: number;
-    private _carLuggageMaxValue: number;
     private _isUpdating: boolean;
     private _isCarImageDirty: boolean;
 
@@ -31,11 +31,15 @@ export class CarDetailEditViewModel extends Observable {
 
         this._addRemoveText = faThrashIcon;
 
-        this._carLuggageMinValue = 0;
-        this._carLuggageMaxValue = 5;
-
         this._isUpdating = false;
         this._isCarImageDirty = false;
+
+        // set up value converter to force iOS UISlider to work with discrete steps
+        this._roundingValueConverter = new RoundingValueConverter();
+    }
+
+    get roundingValueConverter(): RoundingValueConverter {
+        return this._roundingValueConverter;
     }
 
     get isUpdating(): boolean {
@@ -62,14 +66,6 @@ export class CarDetailEditViewModel extends Observable {
             this._addRemoveText = value;
             this.notifyPropertyChange("addRemoveText", value);
         }
-    }
-
-    get carLuggageMinValue(): number {
-        return this._carLuggageMinValue;
-    }
-
-    get carLuggageMaxValue(): number {
-        return this._carLuggageMaxValue;
     }
 
     onImageAddRemove(): void {

--- a/cars/car-detail-edit-page/roundingValueConverter.ts
+++ b/cars/car-detail-edit-page/roundingValueConverter.ts
@@ -1,0 +1,9 @@
+export class RoundingValueConverter {
+    toView(value: number): number {
+        return value;
+    }
+
+    toModel(value: number): number {
+        return Math.round(value);
+    }
+}


### PR DESCRIPTION
Force iOS UISlider instances on "Edit" screen (luggage, price per day) to work with discrete steps as is the default behavior in Android (and expected behavior in this scenario).