### PR TITLE
improve ux through page init changes

### DIFF
--- a/cars/car-detail-edit-page/car-detail-edit-page.ts
+++ b/cars/car-detail-edit-page/car-detail-edit-page.ts
@@ -1,7 +1,9 @@
 import { EventData } from "data/observable";
+import { ActionItem } from "ui/action-bar";
 import { alert } from "ui/dialogs";
 import { topmost } from "ui/frame";
-import { Page } from "ui/page";
+import { GridLayout } from "ui/layouts/grid-layout";
+import { NavigatedData, Page } from "ui/page";
 
 import { CarDetailEditViewModel } from "./car-detail-edit-view-model";
 
@@ -9,32 +11,37 @@ import { CarDetailEditViewModel } from "./car-detail-edit-view-model";
 * This is the item detail edit code behind.
 * This code behind gets the selected data item, provides options to edit the item and saves the changes.
 *************************************************************/
-let viewModel: CarDetailEditViewModel;
 
 /* ***********************************************************
 * Use the "onNavigatingTo" handler to get the data item id parameter passed through navigation.
-* Use it to initialize the view model and assign it to the view.
+* Use it to initialize the view model and assign it as a view binding context.
 *************************************************************/
-export function onNavigatingTo(args: EventData): void {
+export function onNavigatingTo(args: NavigatedData): void {
+    /* ***********************************************************
+    * The "onNavigatingTo" event handler lets you detect if the user navigated with a back button.
+    * Skipping the re-initialization on back navigation means the user will see the
+    * page in the same data state that he left it in before navigating.
+    *************************************************************/
+    if (args.isBackNavigation) {
+        return;
+    }
+
     const page = <Page>args.object;
 
-    if (!page.bindingContext) {
-        viewModel = new CarDetailEditViewModel(page.navigationContext);
-        page.bindingContext = viewModel;
-    }
+    page.bindingContext = new CarDetailEditViewModel(page.navigationContext);
 }
 
 /* ***********************************************************
 * The edit cancel button navigates back to the item details page.
 *************************************************************/
-export function onCancelButtonTap(): void {
+export function onCancelButtonTap(args: EventData): void {
     topmost().goBack();
 }
 
 /* ***********************************************************
 * The edit done button calls the view model save changes logic.
 *************************************************************/
-export function onDoneButtonTap(): void {
+export function onDoneButtonTap(args: EventData): void {
     /* ***********************************************************
     * By design this app is set up to work with read-only sample data.
     * Follow the steps in the "Firebase database setup" section in app/readme.md file
@@ -42,7 +49,10 @@ export function onDoneButtonTap(): void {
     *************************************************************/
 
     /* ***********************************************************
-    viewModel.saveChanges()
+    const actionItem = <ActionItem>args.object;
+    const bindingContext = <CarDetailEditViewModel>actionItem.bindingContext;
+
+    bindingContext.saveChanges()
         .then(() => topmost().navigate({
             moduleName: "cars/cars-list-page",
             animated: true,
@@ -73,16 +83,18 @@ export function onDoneButtonTap(): void {
         }));
 }
 
-export function onSelectorTap(args): void {
-    const tag = args.object.tag;
-    const selectedValue = viewModel.car[tag];
+export function onSelectorTap(args: EventData): void {
+    const gridLayout = <GridLayout>args.object;
+    const tag = gridLayout.get("tag");
+    const bindingContext = <CarDetailEditViewModel>gridLayout.bindingContext;
+    const selectedValue = bindingContext.car[tag];
     const context = { tag, selectedValue };
     const modalPagePath = "cars/car-detail-edit-page/list-selector/list-selector-modal-page";
-    const page = <Page>args.object.page;
+    const page = <Page>gridLayout.page;
 
     page.showModal(modalPagePath, context, (value: string) => {
         if (value) {
-            viewModel.car[tag] = value;
+            bindingContext.car[tag] = value;
         }
     }, false);
 }

--- a/cars/car-detail-page/car-detail-page.ts
+++ b/cars/car-detail-page/car-detail-page.ts
@@ -1,6 +1,5 @@
-import { EventData } from "data/observable";
 import { topmost } from "ui/frame";
-import { Page } from "ui/page";
+import { NavigatedData, Page } from "ui/page";
 
 import { CarDetailViewModel } from "./car-detail-view-model";
 
@@ -13,7 +12,16 @@ import { CarDetailViewModel } from "./car-detail-view-model";
 /* ***********************************************************
 * Use the "onNavigatingTo" handler to initialize the page binding context.
 *************************************************************/
-export function onNavigatingTo(args: EventData) {
+export function onNavigatingTo(args: NavigatedData): void {
+    /* ***********************************************************
+    * The "onNavigatingTo" event handler lets you detect if the user navigated with a back button.
+    * Skipping the re-initialization on back navigation means the user will see the
+    * page in the same data state that he left it in before navigating.
+    *************************************************************/
+    if (args.isBackNavigation) {
+        return;
+    }
+
     const page = <Page>args.object;
 
     page.bindingContext = new CarDetailViewModel(page.navigationContext);
@@ -31,11 +39,11 @@ export function onBackButtonTap(): void {
 * Check out the edit page in the /cars/car-detail-edit-page folder.
 *************************************************************/
 export function onEditButtonTap(args): void {
-    const tappedCarItem = args.object.bindingContext;
+    const bindingContext = <CarDetailViewModel>args.object.bindingContext;
 
     topmost().navigate({
         moduleName: "cars/car-detail-edit-page/car-detail-edit-page",
-        context: tappedCarItem.car,
+        context: bindingContext.car,
         animated: true,
         transition: {
             name: "slideTop",

--- a/cars/cars-list-page.ts
+++ b/cars/cars-list-page.ts
@@ -1,23 +1,41 @@
-import { EventData } from "data/observable";
 import { ListViewEventData } from "nativescript-telerik-ui/listview";
+import { isAndroid } from "tns-core-modules/platform";
 import { topmost } from "ui/frame";
-import { Page } from "ui/page";
+import { NavigatedData, Page } from "ui/page";
 
 import { CarsListViewModel } from "./cars-list-view-model";
+import { Car } from "./shared/car-model";
 
 /* ***********************************************************
 * This is the master list code behind in the master-detail structure.
 * This code behind gets the data, passes it to the master view and displays it in a list.
 * It also handles the navigation to the details page for each item.
 *************************************************************/
-const viewModel = new CarsListViewModel();
 
 /* ***********************************************************
 * Use the "onNavigatingTo" handler to initialize the page binding context.
-* Call any view model data initialization load here.
 *************************************************************/
-export function onNavigatingTo(args: EventData) {
+export function onNavigatingTo(args: NavigatedData): void {
+    /* ***********************************************************
+    * The "onNavigatingTo" event handler lets you detect if the user navigated with a back button.
+    * Skipping the re-initialization on back navigation means the user will see the
+    * page in the same data state that he left it in before navigating.
+    *************************************************************/
+    if (args.isBackNavigation) {
+        return;
+    }
+
+    /* ***********************************************************
+    * Caching pages on navigation means that their entire state will be saved including scroll position.
+    * For iOS this happens by default. For Android you have to specify this explicitly once on the first
+    * page that is loaded in a frame.
+    *************************************************************/
+    if (isAndroid) {
+        topmost().android.cachePagesOnNavigate = true;
+    }
+
     const page = <Page>args.object;
+    const viewModel = new CarsListViewModel();
 
     page.bindingContext = viewModel;
     viewModel.load();
@@ -30,8 +48,8 @@ export function onNavigatingTo(args: EventData) {
 * Learn more about navigating with a parameter in this documentation article:
 * http://docs.nativescript.org/angular/core-concepts/angular-navigation.html#passing-parameter
 *************************************************************/
-export function onCarItemTap(args: ListViewEventData) {
-    const tappedCarItem = args.view.bindingContext;
+export function onCarItemTap(args: ListViewEventData): void {
+    const tappedCarItem = <Car>args.view.bindingContext;
 
     topmost().navigate({
         moduleName: "cars/car-detail-page/car-detail-page",


### PR DESCRIPTION
Proposed changes:
1. EventData -> NavigatedData - It's just the correct type. This should be changed in all TS templates. isBackNavigation doesn't work without it.

2. On isBackNavigation skip the page view model initialization. - I think this should be the default back handling in mobile applications. Maybe consult a UX expert. There might be cases in which we don't want this.

3. android.cachePagesOnNavigate - This is a bit problematic since the 2 platforms behave differently. Ios has this on by default and you can't change it. Android has this off by default, but I find it better from a UX perspective. The problem is you must set this to the root frame and you can't do this before the first navigation. You have to set this on the first landing page of your app. I think it should be implemented as a static property like Frame.defaultTransition.

4. The code-behind doesn't share the view model variable, but gets the element's binding context instead - this ensures that we modify the correct object that is currently bound.

Let me know what you think.