### PR TITLE
Clean up code with imagepicker plugin update

### DIFF
--- a/cars/shared/car-service.ts
+++ b/cars/shared/car-service.ts
@@ -67,8 +67,7 @@ export class CarService {
         if (data) {
             for (const id in data) {
                 if (data.hasOwnProperty(id)) {
-                    const result = Object.assign({ id }, ...data[id]);
-                    this._cars.push(new Car(result));
+                    this._cars.push(new Car(data[id]));
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "v8Flags": "--expose_gc"
   },
   "dependencies": {
-    "nativescript-imagepicker": "^3.0.1",
-    "nativescript-permissions": "^1.2.3",
+    "nativescript-imagepicker": "~3.0.3",
     "nativescript-plugin-firebase": "^3.12.0",
     "nativescript-telerik-ui": "^3.0.0",
     "nativescript-theme-core": "~1.0.2",


### PR DESCRIPTION
Latest version 3.0.3 of nativescript-imagepicker plugin incorporates the logic for Android 6 & 7 permissions https://github.com/NativeScript/nativescript-imagepicker/issues/66 so we can remove it from our code.

Same approach as https://github.com/NativeScript/template-master-detail-ng/pull/52