### PR TITLE
Clear navigation history when navigate from edit page

### DIFF
--- a/cars/car-detail-edit-page/car-detail-edit-page.ts
+++ b/cars/car-detail-edit-page/car-detail-edit-page.ts
@@ -56,6 +56,7 @@ export function onDoneButtonTap(args: EventData): void {
         .then(() => topmost().navigate({
             moduleName: "cars/cars-list-page",
             animated: true,
+            clearHistory: true,
             transition: {
                 name: "slideBottom",
                 duration: 200,
@@ -75,6 +76,7 @@ export function onDoneButtonTap(args: EventData): void {
         .then(() => topmost().navigate({
             moduleName: "cars/cars-list-page",
             animated: true,
+            clearHistory: true,
             transition: {
                 name: "slideBottom",
                 duration: 200,


### PR DESCRIPTION
Clear navigation history when navigate from edit page after confirm/done operation.
When navigate with android back button from car-list page it should exit the app (now it just goes back to car-edit page).