### PR TITLE
Bump nativescript-imagepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "v8Flags": "--expose_gc"
   },
   "dependencies": {
-    "nativescript-imagepicker": "3.0.6",
+    "nativescript-imagepicker": "3.0.7",
     "nativescript-plugin-firebase": "4.1.1",
     "nativescript-pro-ui": "3.1.4",
     "nativescript-theme-core": "1.0.4",


### PR DESCRIPTION
nativescript-imagepicker 3.0.6 internally referes to `nativescipt-telerik-ui` instead of `nativescipt-pro-ui` 